### PR TITLE
fileio: don't try to mount if remote update is disabled

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -197,6 +197,10 @@ void umount_volume(cam_t *cam)
 
 void mount_volume(cam_t *cam)
 {
+    /* Only try to mount if remote capture is enabled */
+    if (!cam->rcap)
+        return;
+
     /* Prepare a mount operation */
     cam->rdir_file = g_file_new_for_uri(cam->uri);
     if (cam->rdir_file)


### PR DESCRIPTION
The current logic tries to do a remote mount even when
remote mount is not used.

Signed-off-by: Mauro Carvalho Chehab <mchehab+samsung@kernel.org>