### PR TITLE
Add support to displax maximum frame rate per resolution

### DIFF
--- a/data/camorama.schemas.in
+++ b/data/camorama.schemas.in
@@ -99,26 +99,15 @@
     </schema>
 
     <schema>
-      <key>/schemas/apps/camorama/preferences/login</key>
-      <applyto>/apps/camorama/preferences/login</applyto>
+      <key>/schemas/apps/camorama/preferences/remote_proto</key>
+      <applyto>/apps/camorama/preferences/remote_proto</applyto>
       <owner>camorama</owner>
       <type>string</type>
       <default>your-username</default>
       <locale name="C">
-	<short>Username for FTP server</short>
-	<long>Username to use for FTP uploads of captured pictures</long>
-      </locale>
-    </schema>
-
-    <schema>
-      <key>/schemas/apps/camorama/preferences/password</key>
-      <applyto>/apps/camorama/preferences/password</applyto>
-      <owner>camorama</owner>
-      <type>string</type>
-      <default>seeeekrit</default>
-      <locale name="C">
-	<short>Password for FTP server</short>
-	<long>The password for the FTP account for remote captures.</long>
+	<short>Protocol to use for remote access</short>
+	<long>The URI name of the protocol that will be used to connect
+	to a remote server. Can be ftp, sftp or smb</long>
       </locale>
     </schema>
 

--- a/po/am.po
+++ b/po/am.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2003-01-24 11:45+EDT\n"
 "Last-Translator: Ge'ez Frontier Foundation <locales@geez.org>\n"
 "Language-Team: Amharic <locales@geez.org>\n"
@@ -339,6 +339,16 @@ msgstr ""
 msgid "Effects"
 msgstr ""
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr ""
@@ -498,45 +508,45 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
 "Please check connection."
 msgstr ""
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Arabic\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2007-04-14 18:49+0100\n"
 "Last-Translator: Djihed Afifi <djihed@gmail.com>\n"
 "Language-Team: Arabeyes <doc@arabeyes.org>\n"
@@ -374,6 +374,16 @@ msgstr "أضف ملفات"
 msgid "Effects"
 msgstr "مؤ_ثرات"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 #, fuzzy
 msgid "Could save temporary image file in /tmp."
@@ -554,8 +564,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, fuzzy, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -564,37 +574,37 @@ msgstr ""
 "تعذّر الاتّصال بالخادم المحدّد.\n"
 "رجاء افحص اسم الخادم و حاوِل مرّة ثانية."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/az.po
+++ b/po/az.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama.HEAD\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2004-06-17 12:25+0300\n"
 "Last-Translator: Mətin Əmirov <metin@karegen.com>\n"
 "Language-Team: Azerbaijani <translation-team-az@lists.sourceforge.net>\n"
@@ -348,6 +348,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Effektləri Göstər"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Müvəqqəti rəsm faylı /tmp içinə qeyd edilə bilmədi."
@@ -518,8 +528,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -528,37 +538,37 @@ msgstr ""
 "(%s) video avadanlığına bağlana bilmədi.\n"
 "Xahiş edirik, bağlantınızı yoxlayın."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama.HEAD\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2003-02-25 12:41+0200\n"
 "Last-Translator: Vital Khilko <dojlid@mova.org>\n"
 "Language-Team: Belarusian <i18n@mova.org>\n"
@@ -347,6 +347,16 @@ msgstr ""
 msgid "Effects"
 msgstr ""
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr ""
@@ -515,45 +525,45 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
 "Please check connection."
 msgstr ""
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama.HEAD\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2006-04-26 17:46+0300\n"
 "Last-Translator: Vladimir Gerdjikov <gerdjikov@gerdjikovs.net>\n"
 "Language-Team: Bulgarian <dict@fsa-bg.org>\n"
@@ -346,6 +346,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Показване на ефектите"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Временното изображение може да се запише в /tmp"
@@ -515,8 +525,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -525,37 +535,37 @@ msgstr ""
 "Не може да се осъществи връзка с видео устройство (%s).\n"
 "Проверете връзката."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/bs.po
+++ b/po/bs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama.HEAD\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2004-08-31 19:33+0200\n"
 "Last-Translator: Kemal Šanjta <gomez@lugzdk.ba>\n"
 "Language-Team: Bosnian <lokal@linux.org.ba>\n"
@@ -343,6 +343,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Pokaži Efekte"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Ne mogu snimiti privremenu sliku u /tmp."
@@ -513,8 +523,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -523,37 +533,37 @@ msgstr ""
 "Ne mogu se spojiti na video uređaj (%s).\n"
 "Molim vas provjerite vezu."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama 0.17\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2005-02-26 17:37+0100\n"
 "Last-Translator: Francesc Dorca <f.dorca@filnet.es>\n"
 "Language-Team: Catalan <tradgnome@softcatala.org>\n"
@@ -343,6 +343,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Mostra els efectes"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "No s'ha pogut desar el fitxer temporal d'imatge a /tmp."
@@ -514,8 +524,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -524,37 +534,37 @@ msgstr ""
 "No s'ha pogut connectar al dispositiu de vídeo (%s).\n"
 "Comproveu-ne la connexió."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2003-08-30 14:23+0200\n"
 "Last-Translator: Miloslav Trmac <mitr@volny.cz>\n"
 "Language-Team: Czech <cs@li.org>\n"
@@ -340,6 +340,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Zobrazit efekty"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Dočasný obrázek uložen do souboru v /tmp."
@@ -510,8 +520,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -520,37 +530,37 @@ msgstr ""
 "Nelze se připojit k video zařízení (%s).\n"
 "Zkontrolujte prosím připojení."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2003-12-27 20:01+0100\n"
 "Last-Translator: Ole Laursen <olau@hardworking.dk>\n"
 "Language-Team: Danish <dansk@klid.dk>\n"
@@ -340,6 +340,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Vis effekter"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Kunne ikke gemme midlertidig billedfil i /tmp."
@@ -511,8 +521,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -521,37 +531,37 @@ msgstr ""
 "Kunne ikke komme i forbindelse med videoenheden (%s).\n"
 "Kontrollér tilslutningen."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama 0.17\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2006-03-13 23:11+0100\n"
 "Last-Translator: Jens Seidel <jseidel@cvs.gnome.org>\n"
 "Language-Team: German <gnome-de@gnome.org>\n"
@@ -340,6 +340,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Effekte anzeigen"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Temporäre Bilddatei konnte nicht in »/tmp« gespeichert werden."
@@ -509,8 +519,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -519,37 +529,37 @@ msgstr ""
 "Verbindung zum Videogerät (%s) konnte nicht hergestellt werden.\n"
 "Bitte überprüfen Sie die Verbindung."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/dz.po
+++ b/po/dz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camora.head.pot\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2007-03-01 16:30+0530\n"
 "Last-Translator: sonam pelden <sonaa_peldn@yahoo.com>\n"
 "Language-Team: Dzongkha <pgeyleg@dit.gov.bt>\n"
@@ -342,6 +342,16 @@ msgstr "ཚགས་མ་ཁ་སྐོང་བརྐྱབ། (_A)"
 msgid "Effects"
 msgstr "ནུས་ཅན་ཚུ་"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "/tmpནང་གནས་སྐབས་ཀྱི་གཟུགས་བརྙན་ཡིག་སྣོད་སྲུང་ཚུགས།"
@@ -508,8 +518,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -518,37 +528,37 @@ msgstr ""
 "ཝི་ཌིའོ་ཐབས་འཕྲུལ་(%s)ལུ་མཐུད་མ་ཚུགས།\n"
 "མཐུད་ལམ་ཞིབ་དཔྱད་འབད།"
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2004-09-11 02:24-0400\n"
 "Last-Translator: Adam Weinberger <adamw@gnome.org>\n"
 "Language-Team: Canadian English <adamw@gnome.org>\n"
@@ -339,6 +339,16 @@ msgstr "_Add Filter"
 msgid "Effects"
 msgstr "Effects"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Could not save temporary image file in /tmp."
@@ -505,8 +515,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -515,37 +525,37 @@ msgstr ""
 "Could not connect to video device (%s).\n"
 "Please check connection."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2007-01-03 20:08-0000\n"
 "Last-Translator: David Lodge <dave@cirt.net>\n"
 "Language-Team: \n"
@@ -341,6 +341,16 @@ msgstr "_Add Filter"
 msgid "Effects"
 msgstr "Effects"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Could save temporary image file in /tmp."
@@ -507,8 +517,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -517,37 +527,37 @@ msgstr ""
 "Could not connect to video device (%s).\n"
 "Please check connection."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-terminal-doc\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2006-12-11 17:58+0100\n"
 "Last-Translator: Francisco Javier F. Serrador <serrador@cvs.gnome.org>\n"
 "Language-Team: Spanish <traductores@es.gnome.org>\n"
@@ -344,6 +344,16 @@ msgstr "_Añadir filtro"
 msgid "Effects"
 msgstr "Efectos"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "No se ha podido guardar el archivo temporal de imagen en /tmp."
@@ -510,8 +520,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -520,37 +530,37 @@ msgstr ""
 "No se ha podido conectar al dispositivo de vídeo (%s).\n"
 "Por favor revise la conexión."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: eu\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2007-08-08 20:14+0200\n"
 "Last-Translator: Iñaki Larrañaga Murgoitio <dooteo@zundan.com>\n"
 "Language-Team: Basque <eu@li.org>\n"
@@ -344,6 +344,16 @@ msgstr "_Gehitu iragazkia"
 msgid "Effects"
 msgstr "Efektuak"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Behin-behineko irudi-fitxategia ezin izan da /tmp direktorioan gorde."
@@ -510,8 +520,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -520,37 +530,37 @@ msgstr ""
 "Bideo gailuarekin ezin izan da konektatu (%s).\n"
 "Konexioa aztertu, mesedez."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2003-03-16 13:47+0330\n"
 "Last-Translator: Roozbeh Pournader <roozbeh@sharif.edu>\n"
 "Language-Team: Persian <farsi@lists.sharif.edu>\n"
@@ -338,6 +338,16 @@ msgstr ""
 msgid "Effects"
 msgstr ""
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr ""
@@ -499,45 +509,45 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
 "Please check connection."
 msgstr ""
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2006-09-15 15:34+0300\n"
 "Last-Translator: Ilkka Tuohela <hile@iki.fi>\n"
 "Language-Team: Finnish <gnome-fi-laatu@lists.sourceforge.net>\n"
@@ -342,6 +342,16 @@ msgstr "_Lisää suodin"
 msgid "Effects"
 msgstr "Tehosteet"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Väliaikaistiedostoa ei voitu tallentaa hakemistoon /tmp."
@@ -508,8 +518,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -518,37 +528,37 @@ msgstr ""
 "Videolaitteeseen %s ei saatu yhteyttä.\n"
 "Tarkista yhteys kameraan."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama 0.17\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2007-03-04 12:53+0100\n"
 "Last-Translator: Stéphane Raimbault <stephane.raimbault@gmail.com>\n"
 "Language-Team: GNOME French Team <gnomefr@traduc.org>\n"
@@ -346,6 +346,16 @@ msgstr "_Ajouter un filtre"
 msgid "Effects"
 msgstr "Effets"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Possibilité d'enregistrer les images temporaires dans /tmp."
@@ -512,8 +522,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -522,37 +532,37 @@ msgstr ""
 "Impossible de se connecter au périphérique vidéo (%s).\n"
 "Veuillez vérifier la connexion."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/ga.po
+++ b/po/ga.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama HEAD\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2004-02-04 07:10+0000\n"
 "Last-Translator: Alastair McKinstry <mckinstry@computer.org>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
@@ -337,6 +337,16 @@ msgstr ""
 msgid "Effects"
 msgstr ""
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr ""
@@ -500,45 +510,45 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
 "Please check connection."
 msgstr ""
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gl\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2006-12-12 03:00+0100\n"
 "Last-Translator: Ignacio Casal Quinteiro <icq@cvs.gnome.org>\n"
 "Language-Team: Galego <trasno@ceu.fi.udc.es>\n"
@@ -345,6 +345,16 @@ msgstr "_Engadir filtro"
 msgid "Effects"
 msgstr "Efectos"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Poderías gardar unha imaxen do ficheiro temporalmente en /tmp "
@@ -511,8 +521,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -521,37 +531,37 @@ msgstr ""
 "Non se pode conectar co dispositivo de vídeo (%s) \n"
 "Por favor revisa a conexión."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/gu.po
+++ b/po/gu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama.HEAD\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2004-09-08 18:14+0530\n"
 "Last-Translator: Ankit Patel <ankit@redhat.com>\n"
 "Language-Team: Gujarati\n"
@@ -343,6 +343,16 @@ msgstr ""
 msgid "Effects"
 msgstr "અસરો બતાવો"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr ""
@@ -505,45 +515,45 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
 "Please check connection."
 msgstr ""
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama.HEAD.hi\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2003-08-13 19:29+0530\n"
 "Last-Translator: G Karunakar <karunakar@freedomink.org>\n"
 "Language-Team: Hindi <indlinux-hindi-gnome@lists.sourceforge.net>\n"
@@ -340,6 +340,16 @@ msgstr ""
 msgid "Effects"
 msgstr ""
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr ""
@@ -506,45 +516,45 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
 "Please check connection."
 msgstr ""
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama 0\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2004-03-17 23:51+CET\n"
 "Last-Translator: auto\n"
 "Language-Team: Croatian <lokalizacija@linux.hr>\n"
@@ -334,6 +334,16 @@ msgstr ""
 msgid "Effects"
 msgstr ""
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr ""
@@ -497,45 +507,45 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
 "Please check connection."
 msgstr ""
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2004-03-13 00:00+0100\n"
 "Last-Translator: Alessio Dessì <alkex@inwind.it>\n"
 "Language-Team: IT <tp@lists.linux.it>\n"
@@ -340,6 +340,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Mostra gli effetti"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "È possibile salvare i file di immagine temporanei in /tmp."
@@ -510,8 +520,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -520,37 +530,37 @@ msgstr ""
 "Impossibile collegarsi al device video (%s).\n"
 "Controllare la connessione."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama HEAD\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2007-05-03 15:21+0900\n"
 "Last-Translator: Takeshi AIHANA <takeshi.aihana@gmail.com>\n"
 "Language-Team: Japanese <gnome-translation@gnome.gr.jp>\n"
@@ -343,6 +343,16 @@ msgstr "フィルタの追加(_A)"
 msgid "Effects"
 msgstr "画像の効果"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "/tmp に画像ファイルを一時的に保存しました。"
@@ -508,8 +518,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -518,37 +528,37 @@ msgstr ""
 "ビデオ・デバイス (%s) に接続できませんでした。\n"
 "接続を確認して下さい。"
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama.HEAD\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2006-06-27 15:46+0300\n"
 "Last-Translator: Raivis Dejus <orvils@gmail.com>\n"
 "Language-Team: Latvian <locale@laka.lv>\n"
@@ -344,6 +344,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Parādīt Efektus"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Varēja saglabāt pagaidu faila attēlu /tmp."
@@ -510,8 +520,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -520,37 +530,37 @@ msgstr ""
 "nevar piekļūt video iekārtai (%s).\n"
 "lūdzu pārbaudiet savienojumu."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/mk.po
+++ b/po/mk.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama mk\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2004-09-17 00:09+0200\n"
 "Last-Translator: Томислав Марковски <tome@users.ossm.org.mk>\n"
 "Language-Team: Macedonian <mk@li.org>\n"
@@ -345,6 +345,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Покажи ефекти"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Може да снима привремени датотеки на слики во /tmp."
@@ -515,8 +525,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -525,37 +535,37 @@ msgstr ""
 "Не можам да се врзе со видео уредот (%s).\n"
 "Проверете ја Вашата конекција."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/ml.po
+++ b/po/ml.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:camorama.HEAD\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2003-07-05 10:29+0530\n"
 "Last-Translator: FSF-India <locale@gnu.org.in>\n"
 "Language-Team: Malayalam <locale@gnu.org.in>\n"
@@ -336,6 +336,16 @@ msgstr ""
 msgid "Effects"
 msgstr ""
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr ""
@@ -495,45 +505,45 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
 "Please check connection."
 msgstr ""
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/ms.po
+++ b/po/ms.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2002-02-04 00:07+0800\n"
 "Last-Translator: Hasbullah Bin Pit <sebol@ikhlas.com>\n"
 "Language-Team: Projek Gabai <gabai-penyumbang@lists.sourceforge.net>\n"
@@ -341,6 +341,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Papar Kesan"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Tidak boleh fail imej sementara di /tmp."
@@ -512,8 +522,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -522,37 +532,37 @@ msgstr ""
 "Tidak dapat menyambung ke peranti video (%s)\n"
 "Sila semak sambungan."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2006-09-13 13:36+0200\n"
 "Last-Translator: Øivind Hoel <oivind.hoel@gmail.com>\n"
 "Language-Team: Norwegian <i18n-nb@lister.ping.uio.no>\n"
@@ -339,6 +339,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Vis effekter"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Kan ikke lagre mellomlagerbilde i /tmp."
@@ -508,8 +518,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -518,37 +528,37 @@ msgstr ""
 "Kan ikke koble til videoutstyret %s.\n"
 "Vennligst sjekk tilkoblingen."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/ne.po
+++ b/po/ne.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama.HEAD.ne\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2006-07-20 02:50+0545\n"
 "Last-Translator: Shyam Krishna Bal <shyamkrishna_bal@yahoo.com>\n"
 "Language-Team: Nepali <info@mpp.org.np>\n"
@@ -348,6 +348,16 @@ msgstr ""
 msgid "Effects"
 msgstr "प्रभावहरू देखाउनुहोस्"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "अस्थायि छवि /टिएमपि फाइलमा बचत गर्न सकिन्छ।"
@@ -514,8 +524,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -524,37 +534,37 @@ msgstr ""
 "भिडियो यन्त्रमा जडान गर्न सकिएन (%s).\n"
 "कृपया जडान जाँच्नुहोस्।"
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2006-11-19 21:22+0100 \n"
 "Last-Translator: Wouter Bolsterlee <uws+gnome@xs4all.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -338,6 +338,16 @@ msgstr "Filter toe_voegen"
 msgid "Effects"
 msgstr "Effecten"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Kan geen tijdelijk afbeeldingsbestand opslaan in /tmp."
@@ -504,8 +514,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -514,37 +524,37 @@ msgstr ""
 "Kan geen verbinding maken met video-apparaat (%s).\n"
 "Controleer de verbinding."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: carmorama.HEAD\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2004-03-15 20:19+0530\n"
 "Last-Translator: Jaswinder Singh Phulewala <jaswinderlinux@netscape.net>\n"
 "Language-Team: Punjabi\n"
@@ -342,6 +342,16 @@ msgstr ""
 msgid "Effects"
 msgstr "ਪ੍ਭਾਵ ਦਿਖਾਓ"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr " /tmp ਵਿਚ ਆਰਜੀ ਚਿੱਤਰ ਫਾਈਲ ਸੰਭਾਲ ਸਕਿਆ।"
@@ -512,8 +522,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -522,37 +532,37 @@ msgstr ""
 "ਆਵਾਜ ਯੰਤਰ (%s) ਨਾਲ ਸੰਬੰਧ ਨਹੀਂ ਬਣ ਸਕਿਆ।\n"
 "ਕਿਰਪਾ ਕਰਕੇ ਜੋੜ ਦੀ ਜਾਂਚ ਕਰੋ।"
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2003-07-27 23:46+0100\n"
 "Last-Translator: GNOME PL Team <granslators@gnome.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -347,6 +347,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Wyświetlanie efektów"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Nie można zapisać tymczasowego obrazu w /tmp."
@@ -517,8 +527,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -527,37 +537,37 @@ msgstr ""
 "Nie można przyłączyć się do urządzenia wideo (%s).\n"
 "Sprawdź czy jest prawidłowo podłączone."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2.6\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2006-11-21 21:50+0100\n"
 "Last-Translator: Luis Matos <gass@otiliamatos.ath.cx>\n"
 "Language-Team: Portuguese <gnome_pt@yahoogroups.com>\n"
@@ -340,6 +340,16 @@ msgstr "_Adicionar Filtro"
 msgid "Effects"
 msgstr "Efeitos"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Incapaz de gravar o ficheiro temporário de imagem em /tmp."
@@ -506,8 +516,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -516,37 +526,37 @@ msgstr ""
 "Incapaz de se ligar ao dispositivo vídeo (%s).\n"
 "Verifique a sua ligação."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:34-0300\n"
 "PO-Revision-Date: 2018-09-06 17:48-0300\n"
 "Last-Translator: Andre Noel <andrenoel@ubuntu.com>\n"
 "Language-Team: Portuguese/Brazil <gnome-l10n-br@listas.cipspa.org.br>\n"
@@ -345,6 +345,16 @@ msgstr "_Adicionar Filtro"
 msgid "Effects"
 msgstr "Efeitos"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Foi possível salvar a imagem temporária em /tmp."
@@ -512,8 +522,8 @@ msgstr ""
 "Argumento inválido\n"
 "Execute '%s --help'\n"
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -522,41 +532,41 @@ msgstr ""
 "Impossível conectar ao dispositivo de vídeo (%s).\n"
 "Verifique a conexão."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 "VIDIOC_REQBUFS  --  não foi possível requisitar buffers (%s), encerrando...."
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 "VIDIOC_QUERYBUF  --  não foi possível obter informações sobre buffers (%s), "
 "encerrando...."
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr "falha ao mapear os buffers na memória (%s), encerrando..."
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 "VIDIOC_QBUF  --  não foi possível enfileirar buffers (%s), encerrando...."
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr "falha ao iniciar o fluxo de vídeo (%s), encerrando..."
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr "Tempo máximo excedido enquanto esperando quadros com imagens (%s)"
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr "falha ao interromper o fluxo de vídeo (%s), encerrando..."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-18 09:34-0300\n"
-"PO-Revision-Date: 2018-09-06 17:48-0300\n"
+"POT-Creation-Date: 2018-09-18 09:35-0300\n"
+"PO-Revision-Date: 2018-09-18 09:35-0300\n"
 "Last-Translator: Andre Noel <andrenoel@ubuntu.com>\n"
 "Language-Team: Portuguese/Brazil <gnome-l10n-br@listas.cipspa.org.br>\n"
 "Language: pt_BR\n"
@@ -292,18 +292,16 @@ msgid "White Balance:"
 msgstr "Equilíbrio de Branco:"
 
 #: data/camorama-gtk3.ui:67 data/camorama-gtk4.ui:56
-#, fuzzy
 msgid "_Take Picture"
-msgstr "Tirar Fotografia"
+msgstr "_Tirar Fotografia"
 
 #: data/camorama-gtk4.ui:71
 msgid "_Quit"
 msgstr "_Encerrar"
 
 #: data/camorama-gtk4.ui:92
-#, fuzzy
 msgid "_Preferences"
-msgstr "Preferências"
+msgstr "_Preferências"
 
 #: data/camorama-gtk4.ui:161
 msgid "_About"
@@ -348,12 +346,12 @@ msgstr "Efeitos"
 #: src/camorama-window.c:285
 #, c-format
 msgid "%dx%d (max %.1f fps)"
-msgstr ""
+msgstr "%dx%d (max %.1f quadros/s)"
 
 #: src/camorama-window.c:289
 #, c-format
 msgid "%dx%d"
-msgstr ""
+msgstr "%dx%d"
 
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."

--- a/po/rw.po
+++ b/po/rw.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama HEAD\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2005-03-31 20:55-0700\n"
 "Last-Translator: Steve Murphy <murf@e-tools.com>\n"
 "Language-Team: Kinyarwanda <translation-team-rw@lists.sourceforge.net>\n"
@@ -386,6 +386,16 @@ msgstr ""
 msgid "Effects"
 msgstr ""
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 #, fuzzy
 msgid "Could save temporary image file in /tmp."
@@ -556,45 +566,45 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, fuzzy, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
 "Please check connection."
 msgstr "OYA Kwihuza Kuri Videwo... APAREYE Kugenzura... Ukwihuza"
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Camorama HEAD branch\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2006-10-31 16:48+0100\n"
 "Last-Translator: Matic Žgur <mr.zgur@gmail.com>\n"
 "Language-Team: Slovenian <sl@li.org>\n"
@@ -345,6 +345,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Prikaži efekte"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Ni mogoče shraniti trenutne slikovne datoteke v /tmp."
@@ -511,8 +521,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -521,37 +531,37 @@ msgstr ""
 "Povezava z video napravo (%s) ni mogoča.\n"
 "Prosim, preverite povezavo."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/sq.po
+++ b/po/sq.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2004-05-18 11:15+0200\n"
 "Last-Translator: Laurent Dhima <laurenti@alblinux.net>\n"
 "Language-Team: Albanian <gnome-albanian-perkthyesit@lists.sourceforge.net>\n"
@@ -339,6 +339,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Trego efektet"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Është e mundur ruajtja e file të figurave të përkohshme në /tmp."
@@ -509,8 +519,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -519,37 +529,37 @@ msgstr ""
 "Nuk arrij të lidhem me dispozitivin video (%s).\n"
 "Kontrollo lidhjen."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2003-08-27 13:43+0200\n"
 "Last-Translator: Дејан Матијевић <dejan@ns.sympatico.ca>\n"
 "Language-Team: Serbian (sr) <serbiangnome-lista@nongnu.org>\n"
@@ -345,6 +345,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Покажи ефекте"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Могу сачувати привремену датотеку од снимка у /tmp."
@@ -515,8 +525,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -525,37 +535,37 @@ msgstr ""
 "Немогуће се конектовати на видео апарат (%s).\n"
 "Проверите конекцију."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/sr@Latn.po
+++ b/po/sr@Latn.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2003-08-27 13:43+0200\n"
 "Last-Translator: Dejan Matijević <dejan@ns.sympatico.ca>\n"
 "Language-Team: Serbian (sr) <serbiangnome-lista@nongnu.org>\n"
@@ -345,6 +345,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Pokaži efekte"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Mogu sačuvati privremenu datoteku od snimka u /tmp."
@@ -515,8 +525,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -525,37 +535,37 @@ msgstr ""
 "Nemoguće se konektovati na video aparat (%s).\n"
 "Proverite konekciju."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2006-11-18 22:48+0100\n"
 "Last-Translator: Daniel Nylander <po@danielnylander.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -346,6 +346,16 @@ msgstr "_Lägg till filter"
 msgid "Effects"
 msgstr "Effekter"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Kunde inte spara temporära bildfiler i /tmp."
@@ -512,8 +522,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -522,37 +532,37 @@ msgstr ""
 "Kunde inte ansluta till videoenheten (%s).\n"
 "Kontrollera anslutningen."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama.HEAD\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2004-09-13 10:32+0530\n"
 "Last-Translator: Jayaradha N <jaya@pune.redhat.com>\n"
 "Language-Team: Tamil <zhakanini@yahoogroups.com>\n"
@@ -345,6 +345,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Å¢¨Ç×¸ளை க¡மி"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "\tmpஇல் தற்காலிக பிம்பத்-தை சேமிக்க இயலும்"
@@ -513,45 +523,45 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
 "Please check connection."
 msgstr "(%s) என்ற காட்சி சாதனத்தை இணைக்க இயலவில்லைதயவு செய்து  இணைப்-பை சரிபாக்கவும்"
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camaroma 2.6.0\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2003-11-24 15:40+0200\n"
 "Last-Translator: Tamer Sezgin <tamer_sezgin@yahoo.com>\n"
 "Language-Team: Turkish <gnome-turk@gnome.org>\n"
@@ -341,6 +341,16 @@ msgstr ""
 msgid "Effects"
 msgstr "Etkileri Göster"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Geçici resim dosyasını /tmp içerisine kaydedebilir."
@@ -511,8 +521,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -521,37 +531,37 @@ msgstr ""
 "Video cihazına (%s) bağlanamadı.\n"
 "Lütfen bağlantıyı kontrol edin."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2003-04-01 09:08--500\n"
 "Last-Translator: Yuriy Syrota <yuri@renome.rovno.ua>\n"
 "Language-Team: Ukrainian <linux@linux.org.ua>\n"
@@ -343,6 +343,16 @@ msgstr ""
 msgid "Effects"
 msgstr ""
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Не вдалось зберегти тимчасовий файл зображення в /tmp."
@@ -511,8 +521,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -521,37 +531,37 @@ msgstr ""
 "Не вдалося встановити з'єднання з відеопристроєм (%s).\n"
 "Будь ласка, перевірте з'єднання."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama Gnome HEAD\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2006-12-24 13:54+1030\n"
 "Last-Translator: Clytie Siddall <clytie@riverland.net.au>\n"
 "Language-Team: Vietnamese <gnomevi-list@lists.sourceforge.net>\n"
@@ -343,6 +343,16 @@ msgstr "Thê_m bộ lọc"
 msgid "Effects"
 msgstr "Hiệu ứng"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "Có thể lưu tập tin ảnh tạm thời vào « /tmp »."
@@ -509,8 +519,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -519,37 +529,37 @@ msgstr ""
 "Không thể kết nối đến thiết bị ảnh động (%s).\n"
 "Hãy kiểm tra lại kết nối hoạt động."
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2004-11-29 16:39+0800\n"
 "Last-Translator: Funda Wang <fundawang@linux.net.cn>\n"
 "Language-Team: zh_CN <i18n-translation@lists.linux.net.cn>\n"
@@ -342,6 +342,16 @@ msgstr ""
 msgid "Effects"
 msgstr "显示特效"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "将临时图像文件保存到 /tmp。"
@@ -512,8 +522,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -522,37 +532,37 @@ msgstr ""
 "无法连接到视频设备(%s)。\n"
 "请检查连接。"
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: camorama 0.17\n"
 "Report-Msgid-Bugs-To: https://github.com/alessio/camorama\n"
-"POT-Creation-Date: 2018-09-07 11:42-0300\n"
+"POT-Creation-Date: 2018-09-18 09:32-0300\n"
 "PO-Revision-Date: 2005-12-03 20:51+0800\n"
 "Last-Translator: Chao-Hsiung Liao <j_h_liau@yahoo.com.tw>\n"
 "Language-Team: Chinese (traditional) <community@linuxhall.org>\n"
@@ -351,6 +351,16 @@ msgstr ""
 msgid "Effects"
 msgstr "顯示效果"
 
+#: src/camorama-window.c:285
+#, c-format
+msgid "%dx%d (max %.1f fps)"
+msgstr ""
+
+#: src/camorama-window.c:289
+#, c-format
+msgid "%dx%d"
+msgstr ""
+
 #: src/fileio.c:111 src/fileio.c:257
 msgid "Could save temporary image file in /tmp."
 msgstr "無法在 /tmp 中儲存暫存影像檔案。"
@@ -520,8 +530,8 @@ msgid ""
 "Run '%s --help'\n"
 msgstr ""
 
-#: src/v4l.c:122 src/v4l.c:228 src/v4l.c:309 src/v4l.c:378 src/v4l.c:397
-#: src/v4l.c:418
+#: src/v4l.c:146 src/v4l.c:252 src/v4l.c:333 src/v4l.c:402 src/v4l.c:421
+#: src/v4l.c:442
 #, c-format
 msgid ""
 "Could not connect to video device (%s).\n"
@@ -530,37 +540,37 @@ msgstr ""
 "無法連線至視訊裝置 (%s)。\n"
 "請檢查連線。"
 
-#: src/v4l.c:447
+#: src/v4l.c:471
 #, c-format
 msgid "VIDIOC_REQBUFS  --  could not request buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:465
+#: src/v4l.c:489
 #, c-format
 msgid "VIDIOC_QUERYBUF  --  could not query buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:480
+#: src/v4l.c:504
 #, c-format
 msgid "failed to memory map buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:494
+#: src/v4l.c:518
 #, c-format
 msgid "VIDIOC_QBUF  --  could not enqueue buffers (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:504
+#: src/v4l.c:528
 #, c-format
 msgid "failed to start streaming (%s), exiting...."
 msgstr ""
 
-#: src/v4l.c:534
+#: src/v4l.c:558
 #, c-format
 msgid "Timeout while waiting for frames (%s)"
 msgstr ""
 
-#: src/v4l.c:596
+#: src/v4l.c:620
 #, c-format
 msgid "failed to stop streaming (%s), exiting...."
 msgstr ""

--- a/src/camorama-window.c
+++ b/src/camorama-window.c
@@ -279,9 +279,14 @@ void load_interface(cam_t *cam)
 
     if (cam->n_res > 0) {
         for (i = 0; i < cam->n_res; i++) {
-            char name[32];
+            char name[80];
 
-            sprintf(name, "%dx%d", cam->res[i].x, cam->res[i].y);
+            if (cam->res[i].max_fps > 0)
+                    sprintf(name, _("%dx%d (max %.1f fps)"),
+                            cam->res[i].x, cam->res[i].y,
+                            (double)cam->res[i].max_fps);
+                else
+                    sprintf(name, _("%dx%d"), cam->res[i].x, cam->res[i].y);
 
             new_res = gtk_radio_menu_item_new_with_label_from_widget(GTK_RADIO_MENU_ITEM(small_res), name);
             gtk_container_add(GTK_CONTAINER(GTK_WIDGET(gtk_builder_get_object(cam->xml, "menuitem4_menu"))),

--- a/src/v4l.h
+++ b/src/v4l.h
@@ -45,6 +45,7 @@ struct buffer_start_len {
 
 struct resolutions {
     unsigned int x, y;
+    float max_fps;
 };
 
 typedef struct camera {


### PR DESCRIPTION
The V4L2 API allows displaying the maximum frame rate for each resolution. Add support to retrieve such info on cameras that use discrete resolutions (with is almost all of them).

While here, fix the Gconf schema to reflect the 0.20.x changes.