### PR TITLE
Fix compilation with gcc10 / -fno-commo

### DIFF
--- a/src/camorama-globals.h
+++ b/src/camorama-globals.h
@@ -29,10 +29,10 @@
 
 G_BEGIN_DECLS
 
-GtkWidget *prefswindow;
-int frames, frames2, seconds;
-GtkWidget *dentry, *entry2, *string_entry, *format_selection;
-GtkWidget *host_entry, *protocol, *rdir_entry, *filename_entry;
+extern GtkWidget *prefswindow;
+extern int frames, frames2, seconds;
+extern GtkWidget *dentry, *entry2, *string_entry, *format_selection;
+extern GtkWidget *host_entry, *protocol, *rdir_entry, *filename_entry;
 
 G_END_DECLS
 #endif                          /* !CAMORAMA_GLOBALS_H */

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,11 @@
 #include <libv4l2.h>
 #include <stdlib.h>
 
+GtkWidget *prefswindow;
+int frames, frames2, seconds;
+GtkWidget *dentry, *entry2, *string_entry, *format_selection;
+GtkWidget *host_entry, *protocol, *rdir_entry, *filename_entry;
+
 static int ver = 0, max = 0, min;
 static int half = 0, use_read = 0, debug = 0;
 static gchar *video_dev = NULL;


### PR DESCRIPTION
gcc10 defaults to -fno-common, meaning that non static symbols can only
be declared once. Make the declarations in camorama-globals.h extern and
declare them as non extern in main.c to fix building with gcc10.

Signed-off-by: Hans de Goede <hdegoede@redhat.com>