### PR TITLE
Untranslatable menu item names

### DIFF
--- a/data/camorama-gtk2.ui
+++ b/data/camorama-gtk2.ui
@@ -389,7 +389,7 @@
                                           <object class="GtkEntry" id="entry2">
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
-                                            <property name="text" translatable="yes">webcam-capture</property>
+                                            <property name="text" translatable="no">webcam-capture</property>
                                             <property name="primary_icon_activatable">False</property>
                                             <property name="secondary_icon_activatable">False</property>
                                             <property name="primary_icon_sensitive">True</property>

--- a/data/camorama-gtk3.ui
+++ b/data/camorama-gtk3.ui
@@ -1036,7 +1036,7 @@
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="hexpand">True</property>
-                                            <property name="text" translatable="yes">webcam-capture</property>
+                                            <property name="text" translatable="no">webcam-capture</property>
                                             <property name="primary_icon_activatable">False</property>
                                             <property name="secondary_icon_activatable">False</property>
                                           </object>

--- a/data/camorama-gtk4.ui
+++ b/data/camorama-gtk4.ui
@@ -926,7 +926,7 @@
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="hexpand">True</property>
-                                            <property name="text" translatable="yes">webcam-capture</property>
+                                            <property name="text" translatable="no">webcam-capture</property>
                                             <property name="primary_icon_activatable">False</property>
                                             <property name="secondary_icon_activatable">False</property>
                                           </object>


### PR DESCRIPTION
This prevents the entry from not running when launched in locales wherein it is translated
https://translate.fedoraproject.org/translate/camorama/master/nb_NO/?checksum=3de5a9676d767d95
or, possibly launching something else by happen-chance, if you catch my drift.